### PR TITLE
all components can have resources

### DIFF
--- a/pyupdate/ha_custom/custom_components.py
+++ b/pyupdate/ha_custom/custom_components.py
@@ -205,18 +205,15 @@ class CustomComponents():
         """Download extra resources for component."""
         await self.log.debug('downlaod_component_resources', 'Started')
         componentdata = await self.component_data(name)
-        iscomponent = False
-        if componentdata['local_location'].split('/')[-1] == '__init__.py':
-            iscomponent = True
-        if iscomponent:
-            resources = componentdata.get('resources', [])
-            await self.log.debug('downlaod_component_resources', resources)
-            for resource in resources:
-                target = self.base_dir + componentdata['local_location']
-                target = target.split('__init__')[0]
-                target = "{}{}".format(target, resource.split('/')[-1])
-                await self.log.debug(
-                    'downlaod_component_resources', 'resource: ' + resource)
-                await self.log.debug(
-                    'downlaod_component_resources', 'target: ' + target)
-                await common.download_file(target, resource)
+        resources = componentdata.get('resources', [])
+        await self.log.debug('downlaod_component_resources', resources)
+        for resource in resources:
+            target = self.base_dir + componentdata['local_location']
+            remove = target.split('/')[-1]
+            target = target.split(remove)[0]
+            target = "{}{}".format(target, resource.split('/')[-1])
+            await self.log.debug(
+                'downlaod_component_resources', 'resource: ' + resource)
+            await self.log.debug(
+                'downlaod_component_resources', 'target: ' + target)
+            await common.download_file(target, resource)


### PR DESCRIPTION
Allow resources to be downloaded for components that have "." in the name.
All components can now have resources, even those named `sensor.mysensor` and resources are now required, in the form of `__init__.py` and `manifest.json`
currently, any repo that is named `sensor.mysensor` will not download rersources
I found this out by accident when I created the resources file for rpi_power, and although the resources were listed in customjson, they were never downloaded.  I then tried moving the version numbering to the __init__ file, which obviously did not work.

I believe that this should solve this problem, but please note that I have not tested this.  Any guidance would be welcome.